### PR TITLE
Performance generalize

### DIFF
--- a/performance/test_performance.sh
+++ b/performance/test_performance.sh
@@ -33,7 +33,7 @@ fi
 END=`date +%s`
 RUNTIME=$((END-START))
 echo "execution time was" $RUNTIME "seconds"
-if (( $RUNTIME > 40 )); 
+if (( $RUNTIME > 300 )); 
 then
     printf  "\n*********************************\n** FAILURE - TOO SLOW\n*********************************\n\n"
 fi

--- a/performance/test_performance.sh
+++ b/performance/test_performance.sh
@@ -10,13 +10,19 @@ PROFILE=1 # 0=no profile; 1=time; 2=memory
 
 START=`date +%s`
 if [ $PROFILE == 1 ]
-then
-$EXE $PARAM_DIR 1 & PID=$!
-instruments -l 60000 -t Time\ Profiler -p $PID 
+then if (which instruments > /dev/null); then
+	 $EXE $PARAM_DIR 1 & PID=$!
+	 instruments -l 60000 -t Time\ Profiler -p $PID ;
+     else
+	 PROFILE=0;
+     fi
 fi
 if [ $PROFILE == 2 ]
-then
-iprofiler -allocations -T 20s $EXE $PARAM_DIR 1 
+then if (which iprofiler > /dev/null); then
+	 iprofiler -allocations -T 20s $EXE $PARAM_DIR 1;
+     else
+	 PROFILE=0;
+     fi
 fi
 if [ $PROFILE == 0 ]
 then
@@ -27,8 +33,7 @@ fi
 END=`date +%s`
 RUNTIME=$((END-START))
 echo "execution time was" $RUNTIME "seconds"
-if [ $RUNTIME \> 40 ] 
+if (( $RUNTIME > 40 )); 
 then
     printf  "\n*********************************\n** FAILURE - TOO SLOW\n*********************************\n\n"
 fi
-


### PR DESCRIPTION
When I ran the performance tests I noticed several issues.  If I were being really hygenic I might open separate issues for each, but for now I'll just list them:

1.  The script uses tools that are available, as far as I can tell, only on OS-X.  So it aborts with an error on linux.  Though the main test runs, there is no profiling and the last few lines that print the runtime and a warning if it is long do not execute.
2. The current code compares the run time incorrectly, lexicographically instead of numerically.
As a result, 100 > 40 is false.
3. My run time is way over 40s: 152 out of the box, and 108 with -O3 (and removing -g, though I'm not sure that matters), despite have recent, fairly capable machine.  Is 40s still an appropriate cutoff?

The first commit addresses 1 partially; the script now runs regardless of availability of profiling tools.  
The second commit fixes 2.
I have no idea about 3.

Fully addressing 1, so that other platforms can get time or memory profiling information, will require more far-reaching changes.  `gprof` is a common choice, but it requires that the code be compiled (and linked, I think) with special options, `-pg`.